### PR TITLE
[WIP] Implement async validation

### DIFF
--- a/packages/canner/src/hocs/validation.js
+++ b/packages/canner/src/hocs/validation.js
@@ -42,18 +42,22 @@ export default function withValidation(Com: React.ComponentType<*>) {
       const {value} = getValueAndPaths(result.data, paths);
       const isRequiredValid = required ? Boolean(value) : true;
 
+      const {schema, validator, errorMessage} = validation;
+      let validate = null
+
       // Ajv validation
-      const ajv = new Ajv();
-      const validate = ajv.compile(validation);
-      
+      if(schema && !isEmpty(schema)) {
+        const ajv = new Ajv();
+        validate = ajv.compile(schema);
+      }
       // custom validator
-      const {validator, errorMessage} = validation;
       const reject = message => ({error: true, message});
       const validatorResult = (validator && isFunction(validator) ) && validator(value, reject);
   
       let customValid = !(validatorResult && validatorResult.error);
+
       // if value is empty, should not validate with ajv
-      if (customValid && isRequiredValid && (!value || validate(value))) {
+      if (customValid && isRequiredValid && (!(value && isFunction(validate)) || validate(value))) {
         this.setState({
           error: false,
           errorInfo: []

--- a/packages/canner/src/hocs/validation.js
+++ b/packages/canner/src/hocs/validation.js
@@ -3,7 +3,7 @@
 import * as React from 'react';
 import RefId from 'canner-ref-id';
 import Ajv from 'ajv';
-import {isEmpty, isArray, isPlainObject, get} from 'lodash';
+import {isEmpty, isArray, isPlainObject, isFunction, get} from 'lodash';
 import type {HOCProps} from './types';
 
 type State = {
@@ -49,7 +49,7 @@ export default function withValidation(Com: React.ComponentType<*>) {
       // custom validator
       const {validator, errorMessage} = validation;
       const reject = message => ({error: true, message});
-      const validatorResult = validator && validator(value, reject);
+      const validatorResult = (validator && isFunction(validator) ) && validator(value, reject);
   
       let customValid = !(validatorResult && validatorResult.error);
       // if value is empty, should not validate with ajv

--- a/packages/canner/src/hocs/validation.js
+++ b/packages/canner/src/hocs/validation.js
@@ -43,7 +43,7 @@ export default function withValidation(Com: React.ComponentType<*>) {
       const isRequiredValid = required ? Boolean(value) : true;
 
       const {schema, validator, errorMessage} = validation;
-      let validate = null
+      let validate = null;
 
       // Ajv validation
       if(schema && !isEmpty(schema)) {
@@ -52,7 +52,7 @@ export default function withValidation(Com: React.ComponentType<*>) {
       }
       // custom validator
       const reject = message => ({error: true, message});
-      const validatorResult = (validator && isFunction(validator) ) && validator(value, reject);
+      const validatorResult = (validator && isFunction(validator)) && validator(value, reject);
   
       let customValid = !(validatorResult && validatorResult.error);
 

--- a/packages/canner/src/hocs/validation.js
+++ b/packages/canner/src/hocs/validation.js
@@ -12,7 +12,7 @@ type State = {
 }
 
 export default function withValidation(Com: React.ComponentType<*>) {
-  return class ComponentWithValition extends React.Component<HOCProps, State> {
+  return class ComponentWithValidation extends React.Component<HOCProps, State> {
     key: string;
     id: ?string;
     callbackId: ?string;


### PR DESCRIPTION
因為擔心英文言不及意，請讓我用中文敘述一次。
會用第一個部分英文版本另外在 canner/canner 開個 issue，
第二部分會直接去編輯現有的那個 issue。


## Part One
首先，validation 這個物件會整個過一次 ajv.compile()，再把 validator, errorMessage 從 validation 解構出來，在進行後續處理。這很明顯事先有 ajv驗證之後，錯誤訊息和自訂函數才陸陸續續加進來。

 結論上，我覺得這種混在一起的方式相當不好，主要有幾個問題：
 
 * 不好進行 Type checking 也不好做 Type Management ，等於要解構別人已經定義好的型別再插入其他的屬性，也怕這些或者往後多加進去的屬性影響 ajv 運作，或跟 ajv 的命名衝突；也有可能是反過來是 ajv 往後如果多加了 validator和errorMessage 的 options 讓命名衝突。

> 現在 canner下的[ 型別定義](https://github.com/Canner/canner/blob/canary/packages/canner/src/hocs/types.js#L20)
> 其實只做了很粗淺定義而已
> 可以對照 ajv下的[ 規格說明 ](https://github.com/epoberezkin/ajv/blob/master/KEYWORDS.md) 作一下補充
 

 * 就是不管有沒有要跑 ajv validation 每個 field 都會起個 ajv instance，這個跟當年 AngularJS 每個數值都要 $watch 監看一樣會影響效能。
 
 我覺得應該把會經過 ajv 的部分 跟我們自定義的 validator, errorMessage 有所區隔，方法大致有兩種。

 一種是直接分成不同 props

```
<string
  keyName="text"
  title="Text"
  validation={{pattern: '^[a-zA-Z0-9]{4,10}$'}}
  customizedValidator={()=>( /* ... */ )}
  errorMessage="Error!"
/>
```
另一種是還在同個props 但在物件中給予獨立的屬性：schema ( ajv 也是用這個關鍵字 )

```
<string
  keyName="text"
  title="Text"
  validation= {{
    schema: {{pattern: '^[a-zA-Z0-9]{4,10}$'}} // JSONSchemaOptions
    validator: {()=>()} //ValidationFunction
    errorMessage="Error!"
  }}
/>

```
只要用 ```const { schema, validator, errorMessage} = validation;``` 解構取值就好
``` javascript
let validate = null
if(schema && !isEmpty(schema)) {
  const ajv = new Ajv();
  validate = ajv.compile(schema);
}
```

只要帶 schema 裡面的東西進去 compile 就好，如果沒 schema 的話連 ajv instance 都不用 new。

## Part Two
再來是這次的主角： Async Validation
比較快的實作會是下面這樣直接套用 [async/await ](https://developer.mozilla.org/zh-TW/docs/Web/JavaScript/Reference/Operators/await)語法
```javascript 
validate = async () => {
 // ...
  let validatorResult = null;
  if(validator && isFunction(validator)) {
    validatorResult = await validator(value, reject);
  }
  // ...
}
```

當然會需要多一些驗證和例外處理，包含 Timeout 。尤其是 validator 帶進來的函式是第三方套件的狀況下。

不過看 canner 的 source code ，只有 server 端有用到 async / await 語法，不知道是不是怕過[ babel ](https://github.com/ssehacker/koa-blog/issues/1)及 webpack 之後會有行為不如預習或有效能的考量？

有鑑於判斷到底是不是 async function/ function with promise return 是一件有點麻煩的事情，在瀏覽器端沒有除了runtime 判斷以外很好的跨瀏覽器解決方案。

極端而言甚至會有這兩種狀態：

```
function foo(bar) {
  if (bar)
    return new Promise(resolve => ...);

   // NOTE: please, never do this!
   return null;
}
```

```
async function x() {}
function y() { return Promise.resolve(); }
function z() { return y() || x(); }
```

如果純用 Promise 解決的情境，我偏好用 類似 Formik [原始碼](https://github.com/jaredpalmer/formik/blob/master/src/Formik.tsx#L180-L187) 與 [文件](https://jaredpalmer.com/formik/docs/api/formik#validate-values-values-formikerrors-values-promise-any)中這種不管哪種傳進來是不是回傳值帶 Promise 都先包一層起來的處理法。

包含原本的 ajv 驗證都 promise 化，用 promise.all 再把回傳值 map reduce的方式去處理，會比較清爽一點。

另外，因為是需要時間去處理的程序，可能需要一個地方或者就放在 error message 處，顯示驗證中 ( Validating... ) 的文字敘述，或者其他圖片動畫的示意。